### PR TITLE
4-VORedisRepository-connectionTime-instance-variable-dont-use

### DIFF
--- a/Voyage-Redis-Core.package/VORedisRepository.class/instance/connectionTimeout..st
+++ b/Voyage-Redis-Core.package/VORedisRepository.class/instance/connectionTimeout..st
@@ -1,3 +1,4 @@
 accessing
-connectionTimeout: anObject
-	connectionTimeout := anObject
+connectionTimeout: anInteger
+	connectionTimeout := anInteger.
+	pool connectionTimeout: anInteger 

--- a/Voyage-Redis-Tests.package/VORedisOperationTest.class/instance/testRepositoryConfiguration.st
+++ b/Voyage-Redis-Tests.package/VORedisOperationTest.class/instance/testRepositoryConfiguration.st
@@ -1,0 +1,4 @@
+tests
+testRepositoryConfiguration
+	repository connectionTimeout: 30.
+	self assert: repository pool connectionTimeout equals: 30.


### PR DESCRIPTION
add connectionTimeOut configuration + test fix #4